### PR TITLE
Fix base path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish the nextjs application to gh-pages
 on:
   push:
-    branches: [main]
+    branches: [fix-base-path]
 
 env:
   APP_ENV: production

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish the nextjs application to gh-pages
 on:
   push:
-    branches: [fix-base-path]
+    branches: [main]
 
 env:
   APP_ENV: production

--- a/components/map-preview.js
+++ b/components/map-preview.js
@@ -30,6 +30,7 @@ const Route = ({ track }) => {
 
   useEffect(() => {
     const url = path.join(basePath, track);
+    console.log("basePath = ", basePath);
 
     // Replace .gpx with .geojson
     const geojsonFile = url.replace(".gpx", ".geojson");

--- a/components/map-preview.js
+++ b/components/map-preview.js
@@ -2,9 +2,9 @@ import { MapContainer } from "react-leaflet/MapContainer";
 import { TileLayer } from "react-leaflet/TileLayer";
 import { GeoJSON, useMap } from "react-leaflet";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import { bounds } from "leaflet";
 import path from "path";
-import { basePath } from "../next.config";
 
 const getBounds = (coordinates) => {
   const [minLat, minLon, maxLat, maxLon] = coordinates.reduce(
@@ -27,10 +27,10 @@ const Route = ({ track }) => {
   // See https://stackoverflow.com/questions/68758035/how-to-render-geojson-polygon-in-react-leaflet-mapcontainer
   const [geojson, setGeojson] = useState(0);
   const map = useMap();
+  const router = useRouter();
 
   useEffect(() => {
-    const url = path.join(basePath, track);
-    console.log("basePath = ", basePath);
+    const url = path.join(router.basePath, track);
 
     // Replace .gpx with .geojson
     const geojsonFile = url.replace(".gpx", ".geojson");

--- a/components/post-header.js
+++ b/components/post-header.js
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
 import path from "path";
-import { basePath } from "../next.config";
 
 import DateFormatter from "../components/date-formatter";
 import PostTitle from "../components/post-title";
@@ -10,7 +10,8 @@ const DynamicComponentWithNoSSR = dynamic(() => import("./map-preview"), {
 });
 
 export default function PostHeader({ title, track, date }) {
-  const downloadUrl = path.join(basePath, track);
+  const router = useRouter();
+  const downloadUrl = path.join(router.basePath, track);
 
   return (
     <>


### PR DESCRIPTION
Apparently, in components you can't use `import { basePath } from "./next.config"`, so we revert the change and reintroduce the use of Router.